### PR TITLE
Fixes bug with embedded tags

### DIFF
--- a/js/FeedEk.js
+++ b/js/FeedEk.js
@@ -52,7 +52,8 @@
                     if (def.ShowDesc) {
                         s += '<div class="itemContent">';
                          if (def.DescCharacterLimit > 0 && itm.channel.item.description.length > def.DescCharacterLimit) {
-                            s += itm.channel.item.description.substring(0, def.DescCharacterLimit) + '...';
+                            var d = $(itm.channel.item.description).text();
+                            s += d.substring(0, def.DescCharacterLimit) + '...';
                         }
                         else {
                             s += itm.channel.item.description;


### PR DESCRIPTION
If the item.description contains embedded tags, and if the text truncation happens to land in the middle of a tag, the formatting of the resulting description gets broken. For example, if the text contains <a href="something"> and the truncation happens inside that tag, then the tag never closes, and the rest of the page is broken.

The proposes fix strips out all tags, which might not be expected behavior for everyone, but fixes that problem.